### PR TITLE
Build for linux/arm/v7 (RPi 3)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/build-push-action@v4.0.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: "ghcr.io/convos-chat/convos-base:main"
           push: true
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I tried to run convos-chat on my RPi 3B+, but found out that there are no docker images for `linux/arm/v7`.

Built the image via buildx locally on my laptop and it's running fine on the RPi 3B+.