### PR TITLE
fix convos/#885

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ LABEL maintainer="contact@convos.chat"
 ADD https://cpanmin.us/ /bin/cpanm
 RUN chmod 0755 /bin/cpanm
 
+ENV CRYPT_ARGON2_ARCH=NONE
+
 RUN apk add --no-cache curl openssl perl perl-io-socket-ssl perl-net-ssleay wget && \
   apk add --no-cache --virtual builddeps build-base perl-dev && \
   /bin/cpanm -n -M https://cpan.metacpan.org \


### PR DESCRIPTION
fix as suggested by @jberger in https://github.com/convos-chat/convos/pull/892

Tested on my VM with qemu x86_64-v2-AES CPU, with this as the base, the convos image is able to successfully launch. Should also resolve https://github.com/convos-chat/convos/issues/885 as I was getting exit code 123 before this, and now it is working correctly.